### PR TITLE
引数が空だったときに、ヘルプを表示して抜けるように変更

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,7 +18,7 @@
 
             .argv;
 
-    if (argv.h) {
+    if (argv.h || argv._.length == 0) {
         optimist.showHelp();
         return;
     }


### PR DESCRIPTION
現在引数が空の状態でmdwcコマンドを呼び出すと、エラーが発生してしまいます。
引数が空だったときはargv.hが設定されているものとみなして、ヘルプを出して抜けるように変更しました。