### PR TITLE
最初の行から一つ目のセクションがはじまっている場合、rootを表示しないよう変更

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,9 +35,15 @@
             );
         });
     } else {
+        let base = 1;
+        if(result.sections.length > 1 && result.sections[0].length == result.sections[1].length){
+            // 最初の行からセクションがはじまっている＝rootと第一セクションの字数が同じになるのでrootの表記をやめる
+            result.sections.shift();
+            base = 0;
+        }
         result.sections.forEach(function (section) {
             console.log([
-                (new Array(section.floor + 1)).join('  '),
+                (new Array(section.floor + base)).join('  '),
                 '-'.grey,
                 (section.name || 'root'.grey),
                 ['(', section.length, ')'].join('').green


### PR DESCRIPTION
最初の行から一つ目のセクションがはじまっている場合、rootを出力に表示し、以降をインデントしてしまうのは、出力の行数が増え、出力の視認性低下につながります。

このため、rootの文字数＝一つ目のセクションの文字数だった場合は、最初の行から一つ目のセクションがはじまっているとみなし、rootを表示しないようにしました。